### PR TITLE
Revamping player attack class done

### DIFF
--- a/Assets/Resources/Events/ItemScriptableObject.cs
+++ b/Assets/Resources/Events/ItemScriptableObject.cs
@@ -14,12 +14,6 @@ public abstract class ItemScriptableObject : ScriptableObject
     [SerializeField] private float coolDownTime;
     public float CoolDownTime => coolDownTime;
 
-    //[SerializeField] private bool isPieringWeapon;
-    //public bool IsPiercingWeapon => isPieringWeapon;
-
-    //[SerializeField] private bool isKnockBackWeapon;
-    //public bool IsKnockBackWeapon => isKnockBackWeapon;
-
     [SerializeField] private int initDamage;
     public int InitDamage => initDamage;
 
@@ -44,15 +38,6 @@ public abstract class ItemScriptableObject : ScriptableObject
         }
     }
 
-    //[SerializeField] private bool isHomingWeapon;
-    //public bool IsHomingWeapon
-    //{
-    //    get
-    //    {
-    //        return isHomingWeapon;
-    //    }
-    //}
-
     [SerializeField] private float projectileAngle;
     public float ProjectileAngle
     {
@@ -60,6 +45,16 @@ public abstract class ItemScriptableObject : ScriptableObject
         {
             return projectileAngle;
         }
+    }
+
+    public BulletPattern ProjectilePattern;
+
+    public enum BulletPattern
+    {
+        Straight,
+        Orbit,
+        Boomerang,
+        Aura
     }
 }
 

--- a/Assets/Resources/Player/AttackScheduler.cs
+++ b/Assets/Resources/Player/AttackScheduler.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// This class is used for weapons with projectile patterns = straight, boomerang
+/// <summary>
+public class AttackScheduler
+{
+	// A registry that knows how to spawn bullets for each type of weapon
+	private readonly IBulletSpawnerRegistry spawners;
+
+	// Provides the time difference between frames (DeltaTime)
+	private readonly ITimeProvider time;
+
+	// Keeps track of cooldown time for each weapon by name
+	// Key = weapon name (string), Value = time passed since last shot (float)
+	private readonly Dictionary<string, float> cooldownElapsed = new Dictionary<string, float>();
+
+	// Constructor: we pass in the spawner system and the time provider
+	public AttackScheduler(IBulletSpawnerRegistry spawners, ITimeProvider time)
+	{
+		this.spawners = spawners;
+		this.time = time;
+	}
+
+	// This method is called every frame to update weapon firing
+	public void UpdateWeaponFiring(IEnumerable<SlotClass> slots, Vector3 spawnPosition)
+	{
+		// If there are no slots to check, stop here
+		if (slots == null)
+		{
+			return;
+		}
+
+		// Go through each slot (slot can contain a weapon)
+		foreach (SlotClass slot in slots)
+		{
+			// If the slot itself is empty, skip it
+			if (slot == null)
+			{
+				continue;
+			}
+
+			// Try to get the weapon from the slot
+			WeaponClass weapon = slot.GetItem() as WeaponClass;
+			if (weapon == null)
+			{
+				// If the slot doesn't contain a weapon, skip it
+				continue;
+			}
+
+			// Use the weapon's name as a unique ID
+			string weaponId = weapon.ItemName;
+
+			if (weapon.ProjectilePattern == ItemScriptableObject.BulletPattern.Straight)
+			{
+				// If this is the first time we see this weapon, start its cooldown timer at 0
+				if (!cooldownElapsed.ContainsKey(weaponId))
+				{
+					cooldownElapsed[weaponId] = 0f;
+				}
+
+				// Add the time that passed since last frame to the weapon's cooldown timer
+				cooldownElapsed[weaponId] += time.DeltaTime;
+
+				// If the cooldown timer hasn't reached the weapon's cooldown requirement, skip firing
+				if (cooldownElapsed[weaponId] < weapon.CoolDownTime)
+				{
+					continue;
+				}
+
+				// If enough time has passed, try to get a bullet spawner for this weapon
+				if (spawners.TryGetSpawner(weaponId, out IBulletSpawner spawner))
+				{
+					// Spawn as many projectiles as the weapon says it should
+					for (int i = 0; i < weapon.NumberOfProjectiles; i++)
+					{
+						// Spawn the projectile at the given position
+						spawner.Spawn(spawnPosition);
+					}
+				}
+
+				// Reset the cooldown timer for this weapon, since it just fired
+				cooldownElapsed[weaponId] = 0f;
+			}
+		}
+	}
+}

--- a/Assets/Resources/Player/AttackScheduler.cs.meta
+++ b/Assets/Resources/Player/AttackScheduler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3e0c2105c82fcde42989cdf80d1304ca

--- a/Assets/Resources/Player/BulletSpawnerRegistry.cs
+++ b/Assets/Resources/Player/BulletSpawnerRegistry.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+public class BulletSpawnerRegistry : IBulletSpawnerRegistry
+{
+	private readonly Dictionary<string, IBulletSpawner> map;
+
+	public BulletSpawnerRegistry()
+	{
+		map = new Dictionary<string, IBulletSpawner>
+		{
+			{ "Shotgun", new DelegateSpawner(position => ShotgunBulletPool.Instance.SpawnBullet(position)) },
+			{ "Heugabel", new DelegateSpawner(position => HeugabelBulletPool.Instance.SpawnBullet(position)) },
+			{ "Schaufel", new DelegateSpawner(position => SchaufelBulletPool.Instance.SpawnBullet(position)) },
+			{ "Sichel", new DelegateSpawner(position => SichelBulletPool.Instance.SpawnBullet(position)) },
+		};
+	}
+
+	public bool TryGetSpawner(string id, out IBulletSpawner spawner) => map.TryGetValue(id, out spawner);
+
+	private class DelegateSpawner : IBulletSpawner
+	{
+		private readonly System.Action<Vector3> spawnAction;
+		public DelegateSpawner(System.Action<Vector3> spawnAction) { this.spawnAction = spawnAction; }
+		public void Spawn(Vector3 position) => spawnAction(position);
+	}
+}

--- a/Assets/Resources/Player/BulletSpawnerRegistry.cs.meta
+++ b/Assets/Resources/Player/BulletSpawnerRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8e6657a90e782b24b98b50528ac125dd

--- a/Assets/Resources/Player/Bullets/Behaviors/BehaviorDefault.cs
+++ b/Assets/Resources/Player/Bullets/Behaviors/BehaviorDefault.cs
@@ -13,6 +13,6 @@ public class BehaviorDefault : IDefaultBehavior
 
     public void FlyStraight()
     {
-        bullet.transform.Translate(Vector2.up * bullet.weaponClass.BulletSpeed * Time.deltaTime);
+        bullet.transform.Translate(Vector2.up * bullet.WeaponClass.BulletSpeed * Time.deltaTime);
     }
 }

--- a/Assets/Resources/Player/Bullets/Bullet.cs
+++ b/Assets/Resources/Player/Bullets/Bullet.cs
@@ -6,7 +6,8 @@ public class Bullet : MonoBehaviour
 {
     protected float bulletTimeout = 8.0f;
 
-    public WeaponClass weaponClass;
+    [SerializeField] private WeaponClass weaponClass;
+    public WeaponClass WeaponClass => weaponClass;
 
     public void InitBullet(Vector2 spawnPosition)
     {

--- a/Assets/Resources/Player/Bullets/Interfaces/IBulletSpawner.cs
+++ b/Assets/Resources/Player/Bullets/Interfaces/IBulletSpawner.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public interface IBulletSpawner
+{
+    void Spawn(Vector3 position);
+}

--- a/Assets/Resources/Player/Bullets/Interfaces/IBulletSpawner.cs.meta
+++ b/Assets/Resources/Player/Bullets/Interfaces/IBulletSpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e17afd6cb0ebfa24d813e4743187fd9e

--- a/Assets/Resources/Player/Bullets/Interfaces/IBulletSpawnerRegistry.cs
+++ b/Assets/Resources/Player/Bullets/Interfaces/IBulletSpawnerRegistry.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public interface IBulletSpawnerRegistry
+{
+	bool TryGetSpawner(string weaponId, out IBulletSpawner spawner);
+}

--- a/Assets/Resources/Player/Bullets/Interfaces/IBulletSpawnerRegistry.cs.meta
+++ b/Assets/Resources/Player/Bullets/Interfaces/IBulletSpawnerRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 89455ca369b6f9145b004729a0b3bd75

--- a/Assets/Resources/Player/Bullets/Interfaces/ITimeProvider.cs
+++ b/Assets/Resources/Player/Bullets/Interfaces/ITimeProvider.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public interface ITimeProvider
+{
+	float DeltaTime { get; }
+}

--- a/Assets/Resources/Player/Bullets/Interfaces/ITimeProvider.cs.meta
+++ b/Assets/Resources/Player/Bullets/Interfaces/ITimeProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b933aeba47733d44bb19d2aa94a645c7

--- a/Assets/Resources/Player/Bullets/Sichel.cs
+++ b/Assets/Resources/Player/Bullets/Sichel.cs
@@ -10,7 +10,7 @@ public class Sichel : OrbitBullet
     protected override void Awake()
     {
         base.Awake();
-        BehaviorCirclingBullet = new BehaviorCirclingBullet(this, weaponClass, playerControl);
+        BehaviorCirclingBullet = new BehaviorCirclingBullet(this, WeaponClass, playerControl);
     }
 
     protected override void TriggerReturnToPool()

--- a/Assets/Resources/Player/OrbitAttackInit.cs
+++ b/Assets/Resources/Player/OrbitAttackInit.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Orbit attacks only need to be spawned once!
+/// <summary>
+public class OrbitAttackInit
+{
+    // A registry that knows how to spawn bullets for each type of weapon
+	private readonly IBulletSpawnerRegistry spawners;
+
+    public OrbitAttackInit(IBulletSpawnerRegistry spawners)
+    {
+        this.spawners = spawners;
+    }
+
+    public void SpawnOrbitAttack(IEnumerable<SlotClass> slots, Vector3 spawnPosition)
+    {
+		// If there are no slots to check, stop here
+		if (slots == null)
+		{
+			return;
+		}
+
+		// Go through each slot (slot can contain a weapon)
+		foreach (SlotClass slot in slots)
+		{
+			// If the slot itself is empty, skip it
+			if (slot == null)
+			{
+				continue;
+			}
+
+			// Try to get the weapon from the slot
+			WeaponClass weapon = slot.GetItem() as WeaponClass;
+			if (weapon == null)
+			{
+				// If the slot doesn't contain a weapon, skip it
+				continue;
+			}
+
+			// Use the weapon's name as a unique ID
+			string weaponId = weapon.ItemName;
+
+			if (weapon.ProjectilePattern == ItemScriptableObject.BulletPattern.Orbit)
+			{
+                // If enough time has passed, try to get a bullet spawner for this weapon
+				if (spawners.TryGetSpawner(weaponId, out IBulletSpawner spawner))
+				{
+					// // Spawn as many projectiles as the weapon says it should
+					// for (int i = 0; i < weapon.NumberOfProjectiles; i++)
+					// {
+						// Spawn the projectile at the given position
+						spawner.Spawn(spawnPosition + new Vector3(0 , 1, 0));
+					// }
+				}
+            }
+        }
+    }
+}

--- a/Assets/Resources/Player/OrbitAttackInit.cs.meta
+++ b/Assets/Resources/Player/OrbitAttackInit.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: adc5b44b7457b2f489497871893f07c3

--- a/Assets/Resources/Player/PlayerAttack.cs
+++ b/Assets/Resources/Player/PlayerAttack.cs
@@ -2,88 +2,24 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class PlayerAttack : MonoBehaviour
+public class PlayerAttack
 {
     private PlayerControl playerControl;
-    private float timeCounter;
+    private AttackScheduler scheduler;
+    private IBulletSpawnerRegistry spawnerRegistry;
+    private ITimeProvider timeProvider;
 
-    //[SerializeField] private EnemyController nearestEnemy;
-    //public EnemyController NearestEnemy => nearestEnemy;
-
-    private void Awake()
+    public PlayerAttack(PlayerControl playerControl, AttackScheduler scheduler, IBulletSpawnerRegistry spawnerRegistry, ITimeProvider timeProvider)
     {
-        LoadPlayerControl();
+        this.playerControl = playerControl;
+        this.scheduler = scheduler;
+        this.spawnerRegistry = spawnerRegistry;
+        this.timeProvider = timeProvider;
     }
 
-    private void Update()
+    // Spawn attack through scheduler 
+    public void SpawnAttacks()
     {
-        CheckAttack();
-    }
-
-    // Player attack should reference inventory Manager through player Control
-    private void LoadPlayerControl()
-    {
-        playerControl = gameObject.GetComponentInParent<PlayerControl>();
-    }
-
-    private void SpawnAttack(WeaponClass weapon)
-    {
-        // if the bullet is homing the bullet spawnDirection = direction of nearest enemy
-        if (weapon.ItemName == "Shotgun")
-        {
-            ShotgunBulletPool.Instance.SpawnBullet(this.gameObject.transform.position);
-            //Debug.Log($"{weapon} spawned");
-        }
-
-        if (weapon.ItemName == "Heugabel")
-        {
-            HeugabelBulletPool.Instance.SpawnBullet(this.gameObject.transform.position);
-        }
-
-        if (weapon.ItemName == "Sichel")
-        {
-            SichelBulletPool.Instance.SpawnBullet(this.gameObject.transform.position);
-            //Debug.Log($"{weapon} spawned");
-        }
-
-        if (weapon.ItemName == "Schaufel")
-        {
-            SchaufelBulletPool.Instance.SpawnBullet(this.gameObject.transform.position);
-        }
-    }
-
-    private void CheckAttack()
-    {
-        //if (playerControl.playerAttackRange.InRangeEnemies.Count <= 0)
-        //{
-        //    return;
-        //}
-
-        foreach (SlotClass slot in playerControl.inventoryManager.ItemDB)
-        {
-            if (slot == null)
-            {
-                return;
-            }
-
-            WeaponClass weapon = slot.GetItem() as WeaponClass; // cast 
-
-            if (weapon == null)
-            {
-                Debug.LogWarning($"{weapon} is not a weapon");
-                return;
-            }
-
-            timeCounter = timeCounter + Time.deltaTime;
-
-            if (timeCounter >= weapon.CoolDownTime)
-            {
-                for (int i = 0; i < weapon.NumberOfProjectiles; i++)
-                {
-                    SpawnAttack(weapon);
-                }
-                timeCounter = 0f;
-            }
-        }
+        scheduler.UpdateWeaponFiring(playerControl.inventoryManager.ItemDB, playerControl.transform.position);
     }
 }

--- a/Assets/Resources/Player/PlayerControl.cs
+++ b/Assets/Resources/Player/PlayerControl.cs
@@ -9,6 +9,11 @@ public class PlayerControl : MonoBehaviour
     public Move moveState;
     public PlayerInputActions playerInput;
 
+    private PlayerAttack playerAttack;
+    private AttackScheduler attackScheduler;
+    private IBulletSpawnerRegistry spawnerRegistry;
+    private ITimeProvider timeProvider;
+
     [Header("Components")]
     public Animator animator;
     public Rigidbody2D rb;
@@ -18,18 +23,20 @@ public class PlayerControl : MonoBehaviour
 
     private void Awake()
     {
-        // create new object
+        // create new instances
         stateMachine = new StateMachine();
-
-        // create new objects 
         idleState = new Idle(stateMachine, this);
         moveState = new Move(stateMachine, this);
+        playerInput = new PlayerInputActions();
+
+        // create new instances for player attack
+        timeProvider = new UnityTimeProvider();
+        spawnerRegistry = new BulletSpawnerRegistry();
+        attackScheduler = new AttackScheduler(spawnerRegistry, timeProvider);
+        playerAttack = new PlayerAttack(this, attackScheduler, spawnerRegistry, timeProvider);
 
         // set init state
         stateMachine.InitState(idleState);
-
-        // create new object
-        playerInput = new PlayerInputActions();
 
         // enable input action
         playerInput.Enable();
@@ -53,6 +60,7 @@ public class PlayerControl : MonoBehaviour
         stateMachine.currentState.HandleInput();
         stateMachine.currentState.LogicUpdate();
         stateMachine.currentState.SpriteUpdate();
+        playerAttack.SpawnAttacks();
     }
 
     void FixedUpdate()

--- a/Assets/Resources/Player/UnityTimeProvider.cs
+++ b/Assets/Resources/Player/UnityTimeProvider.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class UnityTimeProvider : ITimeProvider
+{
+	public float DeltaTime => Time.deltaTime;
+}

--- a/Assets/Resources/Player/UnityTimeProvider.cs.meta
+++ b/Assets/Resources/Player/UnityTimeProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cb62d822af3fcbe409efb42d40459cb6

--- a/Assets/Resources/ScriptableObjects/Sichel.asset
+++ b/Assets/Resources/ScriptableObjects/Sichel.asset
@@ -20,3 +20,4 @@ MonoBehaviour:
   numberOfProjectiles: 1
   bulletSpeed: 4
   projectileAngle: 0
+  ProjectilePattern: 1

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2892,7 +2892,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1983513022}
-  - {fileID: 1373323585}
   - {fileID: 1201554165}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3566,50 +3565,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1373323584
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1373323585}
-  - component: {fileID: 1373323586}
-  m_Layer: 0
-  m_Name: PlayerAttack
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1373323585
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1373323584}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1210471025}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1373323586
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1373323584}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d4470716473bf8643a2038d844be305e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1373393781
 GameObject:
   m_ObjectHideFlags: 0
@@ -5260,7 +5215,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   weaponClass: {fileID: 11400000, guid: 6ef5828602bc60f45a0c6f917f5a8475, type: 2}
-  playerControl: {fileID: 0}
+  playerControl: {fileID: 1210471028}
   nearestEnemy: {fileID: 0}
 --- !u!61 &1955795261
 BoxCollider2D:

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 46da0496fa1fc3f4688c2943e791138d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/AttackSchedulerTests.cs.meta
+++ b/Assets/Tests/AttackSchedulerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6088543aae65c2c40a469cabd5757df9


### PR DESCRIPTION
1. Remove MonoBehavior from PlayerAttack class
2. Use DI for better testability
3. Time source: depend on an ITimeProvider so tests can drive time deterministically.
4. Spawning: depend on an abstraction (e.g., IWeaponSpawnerRegistry) instead of calling concrete pools directly.
5. Move attack logic into a plain class (e.g., AttackScheduler) that takes only the inputs it needs (inventory, deltaTime, spawner), and expose a single Tick() method.
6. Replace ItemName string checks with an enum or registry map from weapon-id to spawner.
7. Replace return inside the foreach with continue to avoid aborting the entire check on the first null/non-weapon slot.
8. Accumulate elapsed time per-weapon, not one shared timeCounter for all weapons. This makes behavior correct and unit-testable.
