### PR TITLE
Created scriptable objects for enemy/player stats

### DIFF
--- a/Assets/Resources/Commons.meta
+++ b/Assets/Resources/Commons.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 817d8960dc35d42429b22fb2bb0bb9ad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Commons/EntityWithStats.cs
+++ b/Assets/Resources/Commons/EntityWithStats.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EntityWithStats : ScriptableObject
+{
+    [SerializeField] private float movementSpeed;
+    public float MovementSpeed
+    {
+        get
+        {
+            return movementSpeed;
+        }
+    }
+
+    [SerializeField] private int maxHealth;
+    public int HaxHealth
+    {
+        get
+        {
+            return maxHealth;
+        }
+    }
+}

--- a/Assets/Resources/Commons/EntityWithStats.cs.meta
+++ b/Assets/Resources/Commons/EntityWithStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e52c3f5a1e3d6b84a9a6fe78565d8a22

--- a/Assets/Resources/Enemy/EnemyController.cs
+++ b/Assets/Resources/Enemy/EnemyController.cs
@@ -12,6 +12,7 @@ public class EnemyController : MonoBehaviour
     [Header("Components")]
     public Rigidbody2D rb;
     public PlayerControl playerControl;
+    [SerializeField] private EnemyStats enemyStats;
     //[SerializeField] private Enemy enemy;
 
     private void Awake()
@@ -21,7 +22,7 @@ public class EnemyController : MonoBehaviour
 
         stateMachine = new EnemyStateMachine();
 
-        enemyMoveState = new EnemyMoveState(stateMachine, this);
+        enemyMoveState = new EnemyMoveState(stateMachine, this, enemyStats);
         enemyDieState = new EnemyDieState(stateMachine, this);
         enemyKnockedBackState = new EnemyKnockedBackState(stateMachine, this);
 

--- a/Assets/Resources/Enemy/EnemyMoveState.cs
+++ b/Assets/Resources/Enemy/EnemyMoveState.cs
@@ -6,11 +6,11 @@ public class EnemyMoveState : EnemyState
 {
     private bool isDead;
     private Vector2 forceDirection;
-    private float moveSpeed = 2.0f;
+    private EnemyStats enemyStats;
 
-    public EnemyMoveState(EnemyStateMachine stateMachine, EnemyController enemyController) : base(stateMachine, enemyController)
+    public EnemyMoveState(EnemyStateMachine stateMachine, EnemyController enemyController, EnemyStats enemyStats) : base(stateMachine, enemyController)
     {
-
+        this.enemyStats = enemyStats;
     }
 
     public override void LogicUpdate()
@@ -30,7 +30,7 @@ public class EnemyMoveState : EnemyState
 
         forceDirection = (playerPosition - enemyPosition).normalized;
 
-        enemyController.rb.velocity = forceDirection * moveSpeed;
+        enemyController.rb.velocity = forceDirection * enemyStats.MovementSpeed;
 
         //Debug.Log($"{enemyController.gameObject} has force direction of {forceDirection}");
     }

--- a/Assets/Resources/Enemy/EnemyStats.cs
+++ b/Assets/Resources/Enemy/EnemyStats.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "New Enemy", menuName = "Entity/Enemy")]
+public class EnemyStats : EntityWithStats
+{
+
+}

--- a/Assets/Resources/Enemy/EnemyStats.cs.meta
+++ b/Assets/Resources/Enemy/EnemyStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7bcd030a300c6fe42ae29676c86a39dd

--- a/Assets/Resources/Player/Bullets/Behaviors/BehaviorKnockbackBullet.cs
+++ b/Assets/Resources/Player/Bullets/Behaviors/BehaviorKnockbackBullet.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class BehaviorKnockbackBullet : IKnockbackBullet
 {
     private Bullet bullet;
-    private float knockbackForce = 1.5f;
+    private float knockbackForce = 1.2f;
 
     public BehaviorKnockbackBullet(Bullet bullet)
     {

--- a/Assets/Resources/Player/Move.cs
+++ b/Assets/Resources/Player/Move.cs
@@ -7,11 +7,11 @@ public class Move : State
     private bool isIdling;
     private Vector2 forceDirection;
     private Vector2 inputDirection;
-    private float moveSpeed = 4f;
+    private PlayerStats playerStats;
 
-    public Move(StateMachine stateMachine, PlayerControl playerControl) : base(stateMachine, playerControl)
+    public Move(StateMachine stateMachine, PlayerControl playerControl, PlayerStats playerStats) : base(stateMachine, playerControl)
     {
-
+        this.playerStats = playerStats;
     }
 
     public override void LogicUpdate()
@@ -71,7 +71,7 @@ public class Move : State
 
     public override void PhysicsUpdate()
     {
-        playerControl.rb.velocity = forceDirection * moveSpeed;
+        playerControl.rb.velocity = forceDirection * playerStats.MovementSpeed;
         //Debug.Log(playerControl.rb.velocity.magnitude);
     }
 

--- a/Assets/Resources/Player/PlayerControl.cs
+++ b/Assets/Resources/Player/PlayerControl.cs
@@ -21,13 +21,14 @@ public class PlayerControl : MonoBehaviour
     public Camera playerCamera;
     public InventoryManager inventoryManager;
     public PlayerAttackRange playerAttackRange;
+    [SerializeField] private PlayerStats playerStats;
 
     private void Awake()
     {
         // create new instances
         stateMachine = new StateMachine();
         idleState = new Idle(stateMachine, this);
-        moveState = new Move(stateMachine, this);
+        moveState = new Move(stateMachine, this, playerStats);
         playerInput = new PlayerInputActions();
 
         // create new instances for player attack

--- a/Assets/Resources/Player/PlayerStats.cs
+++ b/Assets/Resources/Player/PlayerStats.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "New Player", menuName = "Entity/Player")]
+public class PlayerStats : EntityWithStats
+{
+    [SerializeField] private float damageReductionPercentage;
+    public float DamageReductionPercentage
+    {
+        get
+        {
+            return damageReductionPercentage;
+        }
+    }
+}

--- a/Assets/Resources/Player/PlayerStats.cs.meta
+++ b/Assets/Resources/Player/PlayerStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e869bfb20738b14dbbf0e28f4b8b88f

--- a/Assets/Resources/ScriptableObjects/Enemy.meta
+++ b/Assets/Resources/ScriptableObjects/Enemy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ab41d2352897ce4aab3c7e29cefeb29
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/Enemy/Demon.asset
+++ b/Assets/Resources/ScriptableObjects/Enemy/Demon.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7bcd030a300c6fe42ae29676c86a39dd, type: 3}
+  m_Name: Demon
+  m_EditorClassIdentifier: 
+  movementSpeed: 3
+  maxHealth: 0

--- a/Assets/Resources/ScriptableObjects/Enemy/Demon.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Enemy/Demon.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f69fef55f06414a4ba1a520ee452330e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/Enemy/Fiend.asset
+++ b/Assets/Resources/ScriptableObjects/Enemy/Fiend.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7bcd030a300c6fe42ae29676c86a39dd, type: 3}
+  m_Name: Fiend
+  m_EditorClassIdentifier: 
+  movementSpeed: 3
+  maxHealth: 0

--- a/Assets/Resources/ScriptableObjects/Enemy/Fiend.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Enemy/Fiend.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 716bff6645e0a194287b5741d0ac121a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/Enemy/Skeleton.asset
+++ b/Assets/Resources/ScriptableObjects/Enemy/Skeleton.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7bcd030a300c6fe42ae29676c86a39dd, type: 3}
+  m_Name: Skeleton
+  m_EditorClassIdentifier: 
+  movementSpeed: 3
+  maxHealth: 0

--- a/Assets/Resources/ScriptableObjects/Enemy/Skeleton.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Enemy/Skeleton.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a72b895896d770442ad53491202d85b2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/Enemy/Zombie.asset
+++ b/Assets/Resources/ScriptableObjects/Enemy/Zombie.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7bcd030a300c6fe42ae29676c86a39dd, type: 3}
+  m_Name: Zombie
+  m_EditorClassIdentifier: 
+  movementSpeed: 3
+  maxHealth: 0

--- a/Assets/Resources/ScriptableObjects/Enemy/Zombie.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Enemy/Zombie.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 831c293e55db0af40b420557557f9f31
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/Player.meta
+++ b/Assets/Resources/ScriptableObjects/Player.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 473a404b3b7f149429a6ba3ce982bd10
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/Player/Player.asset
+++ b/Assets/Resources/ScriptableObjects/Player/Player.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e869bfb20738b14dbbf0e28f4b8b88f, type: 3}
+  m_Name: Player
+  m_EditorClassIdentifier: 
+  movementSpeed: 3.6
+  maxHealth: 0
+  damageReductionPercentage: 0

--- a/Assets/Resources/ScriptableObjects/Player/Player.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Player/Player.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a659c6ede555903449e1d0e599b52ab2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -831,6 +831,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rb: {fileID: 0}
   playerControl: {fileID: 1210471028}
+  enemyStats: {fileID: 11400000, guid: 716bff6645e0a194287b5741d0ac121a, type: 2}
 --- !u!50 &282973363
 Rigidbody2D:
   serializedVersion: 4
@@ -2154,6 +2155,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rb: {fileID: 0}
   playerControl: {fileID: 1210471028}
+  enemyStats: {fileID: 11400000, guid: 831c293e55db0af40b420557557f9f31, type: 2}
 --- !u!212 &892930864
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -2986,6 +2988,7 @@ MonoBehaviour:
   playerCamera: {fileID: 0}
   inventoryManager: {fileID: 1089780613}
   playerAttackRange: {fileID: 0}
+  playerStats: {fileID: 11400000, guid: a659c6ede555903449e1d0e599b52ab2, type: 2}
 --- !u!95 &1210471029
 Animator:
   serializedVersion: 7
@@ -3887,6 +3890,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rb: {fileID: 0}
   playerControl: {fileID: 1210471028}
+  enemyStats: {fileID: 11400000, guid: f69fef55f06414a4ba1a520ee452330e, type: 2}
 --- !u!50 &1548419631
 Rigidbody2D:
   serializedVersion: 4
@@ -4440,6 +4444,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rb: {fileID: 0}
   playerControl: {fileID: 1210471028}
+  enemyStats: {fileID: 11400000, guid: a72b895896d770442ad53491202d85b2, type: 2}
 --- !u!50 &1662547067
 Rigidbody2D:
   serializedVersion: 4


### PR DESCRIPTION
Added scriptable objects as data container for enemy and player stats
Purpose:
Avoid declaring local fields for stats, which makes upgrading difficult and messy. A centralized system for stats is easier to control